### PR TITLE
Enhance ReturnUnit rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ kotlin code.
 
 ## Detected rules
 
-Rule | Detects | Enabled <br /> by default | Requires <br /> [type resolution](https://detekt.github.io/detekt/type-resolution.html)
+Rule | Detects | Properties <br /> with defaults | Requires <br /> [type resolution](https://detekt.github.io/detekt/type-resolution.html)
 --- | --- | --- | ---
-LoopUsage | use of `for`, `while` | :white_check_mark: |
-ReturnStatement | use of `return` statement | :white_check_mark: |
-VariableUsage | use of `var` | :white_check_mark: |
-ReturnUnit | use of function returning `Unit` type | :white_check_mark: | :ballot_box_with_check:
-ClassDefinition | use of object-oriented `class` | |
-AbstractClassDefinition | use of object-oriented `abstract class` |
-ThrowExpression | use of `throw` | :white_check_mark: |
-MutableCollections | use of mutable collections | :white_check_mark: | :ballot_box_with_check:
+LoopUsage | use of `for`, `while` | `active`: true |
+ReturnStatement | use of `return` statement | `active`: true |
+VariableUsage | use of `var` | `active`: true |
+ReturnUnit | use of function returning `Unit` type | `active`: true<br />`checkFunctionType`: true | :ballot_box_with_check:
+ClassDefinition | use of object-oriented `class` | `active`: false |
+AbstractClassDefinition | use of object-oriented `abstract class` | `active`: false |
+ThrowExpression | use of `throw` | `active`: true |
+MutableCollections | use of mutable collections | `active`: true | :ballot_box_with_check:
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rule | Detects | Properties <br /> with defaults | Requires <br /> [type resolut
 LoopUsage | use of `for`, `while` | `active`: true |
 ReturnStatement | use of `return` statement | `active`: true |
 VariableUsage | use of `var` | `active`: true |
-ReturnUnit | use of function returning `Unit` type | `active`: true<br />`checkFunctionType`: true | :ballot_box_with_check:
+ReturnUnit | use of function returning `Unit`, `Nothing`, `Void` | `active`: true<br />`checkFunctionType`: true | :ballot_box_with_check:
 ClassDefinition | use of object-oriented `class` | `active`: false |
 AbstractClassDefinition | use of object-oriented `abstract class` | `active`: false |
 ThrowExpression | use of `throw` | `active`: true |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ val detektVersion = "1.16.0"
 
 dependencies {
     compileOnly("io.gitlab.arturbosch.detekt:detekt-api:$detektVersion")
+    compileOnly("io.gitlab.arturbosch.detekt:detekt-psi-utils:$detektVersion")
     implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.4.31")
     testImplementation("io.gitlab.arturbosch.detekt:detekt-api:$detektVersion")
     testImplementation("io.gitlab.arturbosch.detekt:detekt-test:$detektVersion")

--- a/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
+++ b/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.rules.isMainFunction
 import org.jetbrains.kotlin.asJava.namedUnwrappedElement
 import org.jetbrains.kotlin.builtins.getReturnTypeFromFunctionType
 import org.jetbrains.kotlin.psi.KtFunctionType
@@ -71,6 +72,8 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
+        if (function.isMainFunction()) return
+
         bindingContext.takeIf { it != BindingContext.EMPTY }
             ?.get(BindingContext.FUNCTION, function)
             ?.returnType

--- a/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
+++ b/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
@@ -41,7 +41,7 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
         bindingContext.takeIf { it != BindingContext.EMPTY }
             ?.let(lambdaExpression::getType)
             ?.getReturnTypeFromFunctionType()
-            ?.isUnit()
+            ?.takeIf(KotlinType::isUnit)
             ?.let {
                 val file = lambdaExpression.containingKtFile.name
                 val name = lambdaExpression.parent.namedUnwrappedElement?.name ?: lambdaExpression.name ?: "expression"
@@ -60,7 +60,7 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
         bindingContext.takeIf { it != BindingContext.EMPTY }
             ?.let { type.returnTypeReference }
             ?.getAbbreviatedTypeOrType(bindingContext)
-            ?.isUnit()
+            ?.takeIf(KotlinType::isUnit)
             ?.takeIf { checkFunctionType }
             ?.let {
                 val file = type.containingKtFile

--- a/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
+++ b/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
@@ -7,8 +7,14 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.asJava.namedUnwrappedElement
+import org.jetbrains.kotlin.builtins.getReturnTypeFromFunctionType
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.bindingContextUtil.getAbbreviatedTypeOrType
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.isUnit
 
@@ -26,6 +32,43 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
         "Pure function should return something",
         Debt.TWENTY_MINS
     )
+
+    override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
+        bindingContext.takeIf { it != BindingContext.EMPTY }
+            ?.let(lambdaExpression::getType)
+            ?.getReturnTypeFromFunctionType()
+            ?.isUnit()
+            ?.let {
+                val file = lambdaExpression.containingKtFile.name
+                val name = lambdaExpression.parent.namedUnwrappedElement?.name ?: lambdaExpression.name ?: "expression"
+                report(
+                    CodeSmell(
+                        issue,
+                        Entity.from(lambdaExpression),
+                        message = "Function $name in the file $file returns Unit."
+                    )
+                )
+            }
+        super.visitLambdaExpression(lambdaExpression)
+    }
+
+    override fun visitFunctionType(type: KtFunctionType) {
+        bindingContext.takeIf { it != BindingContext.EMPTY }
+            ?.let { type.returnTypeReference }
+            ?.getAbbreviatedTypeOrType(bindingContext)
+            ?.isUnit()
+            ?.let {
+                val file = type.containingKtFile
+                val name = type.parent.namedUnwrappedElement?.name ?: type.name ?: "type"
+                report(
+                    CodeSmell(
+                        issue, Entity.from(type),
+                        message = "Function $name in the file ${file.name} returns Unit."
+                    )
+                )
+            }
+        super.visitFunctionType(type)
+    }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         bindingContext.takeIf { it != BindingContext.EMPTY }

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -20,6 +20,9 @@ class ReturnUnitSpec : Spek({
         it("find returns of Unit") {
             val messages = subject.lintWithContext(env, impureCode).map(Finding::message)
             assertThat(messages).containsExactly(
+                "Function ImpureUnitFunctionType in the file Test.kt returns Unit.",
+                "Function impureUnitLambda in the file Test.kt returns Unit.",
+                "Function impureParameter in the file Test.kt returns Unit.",
                 "Function impureUnitExplicit in the file Test.kt returns Unit.",
                 "Function impureUnitImplicit in the file Test.kt returns Unit.",
                 "Function impureUnitExpression in the file Test.kt returns Unit.",
@@ -30,6 +33,12 @@ class ReturnUnitSpec : Spek({
 
 private const val impureCode: String =
     """
+        typealias ImpureUnitFunctionType = () -> Unit
+        
+        val impureUnitLambda: ImpureUnitFunction = { }
+
+        fun impureParameterFunction(impureParameter: () -> Unit) = "impure"
+
         fun impureUnitExplicit(): Unit { }
         
         fun impureUnitImplicit() { }

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -46,4 +46,8 @@ private const val impureCode: String =
         fun impureUnitExpression() = Unit
 
         fun pureString() = "pure"
+
+        fun main(args: Array<String>) {
+            // pure
+        }
     """

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -2,6 +2,7 @@ package pl.setblack.detekt.kurepotlin
 
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.setupKotlinEnvironment
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -13,7 +14,7 @@ class ReturnUnitSpec : Spek({
     setupKotlinEnvironment()
     val env: KotlinCoreEnvironment by memoized()
 
-    describe("a rule") {
+    describe("a default rule") {
 
         val subject by memoized { ReturnUnit() }
 
@@ -23,6 +24,20 @@ class ReturnUnitSpec : Spek({
                 "Function ImpureUnitFunctionType in the file Test.kt returns Unit.",
                 "Function impureUnitLambda in the file Test.kt returns Unit.",
                 "Function impureParameter in the file Test.kt returns Unit.",
+                "Function impureUnitExplicit in the file Test.kt returns Unit.",
+                "Function impureUnitImplicit in the file Test.kt returns Unit.",
+                "Function impureUnitExpression in the file Test.kt returns Unit.",
+            )
+        }
+    }
+    describe("a rule not checking function types") {
+
+        val subject by memoized { ReturnUnit(TestConfig("checkFunctionType" to false)) }
+
+        it("find returns of Unit") {
+            val messages = subject.lintWithContext(env, impureCode).map(Finding::message)
+            assertThat(messages).containsExactly(
+                "Function impureUnitLambda in the file Test.kt returns Unit.",
                 "Function impureUnitExplicit in the file Test.kt returns Unit.",
                 "Function impureUnitImplicit in the file Test.kt returns Unit.",
                 "Function impureUnitExpression in the file Test.kt returns Unit.",

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -59,6 +59,8 @@ private const val impureCode: String =
         fun impureUnitImplicit() { }
         
         fun impureUnitExpression() = Unit
+        
+        typealias PureFunctionType = () -> String
 
         fun pureString() = "pure"
 

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -18,39 +18,62 @@ class ReturnUnitSpec : Spek({
 
         val subject by memoized { ReturnUnit() }
 
-        it("find returns of Unit") {
-            val messages = subject.lintWithContext(env, impureCode).map(Finding::message)
+        it("should find returns of Unit") {
+            val messages = subject.lintWithContext(env, impureUnitCode).map(Finding::message)
             assertThat(messages).containsExactly(
-                "Function ImpureUnitFunctionType in the file Test.kt returns Unit.",
-                "Function impureUnitLambda in the file Test.kt returns Unit.",
-                "Function impureParameter in the file Test.kt returns Unit.",
-                "Function impureUnitExplicit in the file Test.kt returns Unit.",
-                "Function impureUnitImplicit in the file Test.kt returns Unit.",
-                "Function impureUnitExpression in the file Test.kt returns Unit.",
+                "Function ImpureUnitFunctionType in the file Test.kt returns nothing.",
+                "Function impureUnitLambda in the file Test.kt returns nothing.",
+                "Function impureParameter in the file Test.kt returns nothing.",
+                "Function impureUnitExplicit in the file Test.kt returns nothing.",
+                "Function impureUnitImplicit in the file Test.kt returns nothing.",
+                "Function impureUnitExpression in the file Test.kt returns nothing.",
+            )
+        }
+
+        it("should find returns of Nothing") {
+            val messages = subject.lintWithContext(env, impureNothingCode).map(Finding::message)
+            assertThat(messages).containsExactly(
+                "Function ImpureNothingFunctionType in the file Test.kt returns nothing.",
+                "Function ImpureNullableNothingFunctionType in the file Test.kt returns nothing.",
+                "Function impureNothingLambda in the file Test.kt returns nothing.",
+                "Function impureParameter in the file Test.kt returns nothing.",
+                "Function impureNothingExplicit in the file Test.kt returns nothing."
+            )
+        }
+
+        it("should find returns of Void") {
+            val messages = subject.lintWithContext(env, impureVoidCode).map(Finding::message)
+            assertThat(messages).containsExactly(
+                "Function ImpureVoidFunctionType in the file Test.kt returns nothing.",
+                "Function ImpureNullableVoidFunctionType in the file Test.kt returns nothing.",
+                "Function impureVoidLambda in the file Test.kt returns nothing.",
+                "Function impureParameter in the file Test.kt returns nothing.",
+                "Function impureVoidExplicit in the file Test.kt returns nothing."
             )
         }
     }
+
     describe("a rule not checking function types") {
 
         val subject by memoized { ReturnUnit(TestConfig("checkFunctionType" to false)) }
 
         it("find returns of Unit") {
-            val messages = subject.lintWithContext(env, impureCode).map(Finding::message)
+            val messages = subject.lintWithContext(env, impureUnitCode).map(Finding::message)
             assertThat(messages).containsExactly(
-                "Function impureUnitLambda in the file Test.kt returns Unit.",
-                "Function impureUnitExplicit in the file Test.kt returns Unit.",
-                "Function impureUnitImplicit in the file Test.kt returns Unit.",
-                "Function impureUnitExpression in the file Test.kt returns Unit.",
+                "Function impureUnitLambda in the file Test.kt returns nothing.",
+                "Function impureUnitExplicit in the file Test.kt returns nothing.",
+                "Function impureUnitImplicit in the file Test.kt returns nothing.",
+                "Function impureUnitExpression in the file Test.kt returns nothing.",
             )
         }
     }
 })
 
-private const val impureCode: String =
+private const val impureUnitCode: String =
     """
         typealias ImpureUnitFunctionType = () -> Unit
         
-        val impureUnitLambda: ImpureUnitFunction = { }
+        val impureUnitLambda: ImpureUnitFunctionType = { }
 
         fun impureParameterFunction(impureParameter: () -> Unit) = "impure"
 
@@ -67,4 +90,30 @@ private const val impureCode: String =
         fun main(args: Array<String>) {
             // pure
         }
+    """
+
+private const val impureNothingCode: String =
+    """
+        typealias ImpureNothingFunctionType = () -> Nothing
+
+        typealias ImpureNullableNothingFunctionType = () -> Nothing?
+        
+        val impureNothingLambda: ImpureNothingFunctionType = { throw Error() }
+
+        fun impureParameterFunction(impureParameter: () -> Nothing) = "impure"
+
+        fun impureNothingExplicit(): Nothing { }
+    """
+
+private const val impureVoidCode: String =
+    """
+        typealias ImpureVoidFunctionType = () -> Void
+        
+        typealias ImpureNullableVoidFunctionType = () -> Void?
+        
+        val impureVoidLambda: ImpureNullableVoidFunctionType = { null }
+
+        fun impureParameterFunction(impureParameter: () -> Void) = "impure"
+
+        fun impureVoidExplicit(): Void { }
     """


### PR DESCRIPTION
I'm not really sure if I didn't make this rule too strict and if not, if the parameter `checkFunctionType` is really necessary or if it should be enabled by default.

Changes for ReturnUnit:
* detect Nothing
* detect Void
* detect return type of a function type (online or typealias)
* detect unnamed lambda return type
* ignore `main` function