### PR TITLE
ReturnUnit rule improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rule | Detects | Properties <br /> with defaults | Requires <br /> [type resolut
 LoopUsage | use of `for`, `while` | `active`: true |
 ReturnStatement | use of `return` statement | `active`: true |
 VariableUsage | use of `var` | `active`: true |
-ReturnUnit | use of function returning `Unit`, `Nothing`, `Void`; unless annotated with an annotation which name is specified in `ignoreAnnotated` | `active`: true<br />`ignoreFunctionType`: false<br />`ignoreAnnotated`: []<br />`ignoreDsl`: false | :ballot_box_with_check:
+ReturnUnit | use of function returning `Unit`, `Nothing`, `Void`; unless annotated with an annotation which name is specified in `ignoredAnnotations` | `active`: true<br />`ignoreFunctionType`: false<br />`ignoredAnnotations`: []<br />`ignoreDsl`: false | :ballot_box_with_check:
 ClassDefinition | use of object-oriented `class` | `active`: false |
 AbstractClassDefinition | use of object-oriented `abstract class` | `active`: false |
 ThrowExpression | use of `throw` | `active`: true |
@@ -54,7 +54,7 @@ impure:
   ReturnUnit:
     active: true
     ignoreFunctionType: false
-    ignoreAnnotated: [ ]
+    ignoredAnnotations: [ ]
     ignoreDsl: false
   ClassDefinition:
     active: false

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Rule | Detects | Properties <br /> with defaults | Requires <br /> [type resolut
 LoopUsage | use of `for`, `while` | `active`: true |
 ReturnStatement | use of `return` statement | `active`: true |
 VariableUsage | use of `var` | `active`: true |
-ReturnUnit | use of function returning `Unit`, `Nothing`, `Void` | `active`: true<br />`checkFunctionType`: true | :ballot_box_with_check:
+ReturnUnit | use of function returning `Unit`, `Nothing`, `Void`; unless annotated with an annotation which name is specified in `ignoreAnnotated` | `active`: true<br />`ignoreFunctionType`: false<br />`ignoreAnnotated`: []<br />`ignoreDsl`: false | :ballot_box_with_check:
 ClassDefinition | use of object-oriented `class` | `active`: false |
 AbstractClassDefinition | use of object-oriented `abstract class` | `active`: false |
 ThrowExpression | use of `throw` | `active`: true |
 MutableCollections | use of mutable collections | `active`: true | :ballot_box_with_check:
-BranchStatement | use of `if` or `when` as statement | :white_check_mark: |
-MissingElse | use of `if` statement without `else` | |
+BranchStatement | use of `if` or `when` as statement | `active`: true |
+MissingElse | use of `if` statement without `else` | `active`: false |
 
 ## Usage
 
@@ -53,6 +53,9 @@ impure:
     active: true
   ReturnUnit:
     active: true
+    ignoreFunctionType: false
+    ignoreAnnotated: [ ]
+    ignoreDsl: false
   ClassDefinition:
     active: false
   AbstractClassDefinition:

--- a/src/main/kotlin/pl/setblack/detekt/kurepotlin/psiExtensions.kt
+++ b/src/main/kotlin/pl/setblack/detekt/kurepotlin/psiExtensions.kt
@@ -1,7 +1,17 @@
 package pl.setblack.detekt.kurepotlin
 
+import io.gitlab.arturbosch.detekt.api.AnnotationExcluder
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtFunctionType
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtTypeAlias
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.psiUtil.getAnnotationEntries
+import org.jetbrains.kotlin.psi.psiUtil.parents
 
 fun KtClass.isInlineClass() =
     hasModifier(KtTokens.INLINE_KEYWORD)
@@ -13,3 +23,31 @@ fun KtClass.isPureType(): Boolean =
         isInlineClass() ||
         isInterface() ||
         isSealed()
+
+fun KtLambdaExpression.isAnnotatedWithAnyOf(annotationSimpleNames: List<String>) =
+    AnnotationExcluder(containingKtFile, annotationSimpleNames).let { excluder ->
+        excluder.shouldExclude(getAnnotationEntries()) ||
+            parents.any { parent ->
+                when (parent) {
+                    is KtProperty -> excluder.shouldExclude(parent.annotationEntries)
+                    is KtNamedFunction -> excluder.shouldExclude(parent.annotationEntries)
+                    else -> false
+                }
+            }
+    }
+
+fun KtFunctionType.isAnnotatedWithAnyOf(annotationSimpleNames: List<String>) =
+    AnnotationExcluder(containingKtFile, annotationSimpleNames).let { excluder ->
+        parents.any { parent ->
+            when (parent) {
+                is KtTypeAlias -> excluder.shouldExclude(parent.annotationEntries)
+                is KtParameter -> excluder.shouldExclude(parent.annotationEntries)
+                is KtTypeReference -> excluder.shouldExclude(parent.annotationEntries)
+                else -> false
+            }
+        }
+    }
+
+fun KtNamedFunction.isAnnotatedWithAnyOf(annotationSimpleNames: List<String>) =
+    AnnotationExcluder(containingKtFile, annotationSimpleNames)
+        .shouldExclude(annotationEntries)

--- a/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
+++ b/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
@@ -33,8 +33,8 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
     private val ignoreFunctionType: Boolean
         get() = valueOrDefault("ignoreFunctionType", false)
 
-    private val ignoreAnnotated: List<String>
-        get() = valueOrDefaultCommaSeparated("ignoreAnnotated", emptyList())
+    private val ignoredAnnotations: List<String>
+        get() = valueOrDefaultCommaSeparated("ignoredAnnotations", emptyList())
 
     private val ignoreDsl: Boolean
         get() = valueOrDefault("ignoreDsl", false)
@@ -52,7 +52,7 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         bindingContext.takeIf { it != BindingContext.EMPTY }
             ?.takeUnless { ignoreDsl && lambdaExpression.isDsl(it) }
-            ?.takeUnless { lambdaExpression.isAnnotatedWithAnyOf(ignoreAnnotated) }
+            ?.takeUnless { lambdaExpression.isAnnotatedWithAnyOf(ignoredAnnotations) }
             ?.let(lambdaExpression::getType)
             ?.getReturnTypeFromFunctionType()
             ?.takeIf(KotlinType::isUnitNothingOrVoid)
@@ -74,7 +74,7 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
         bindingContext.takeIf { it != BindingContext.EMPTY }
             ?.takeUnless { ignoreFunctionType }
             ?.takeUnless { ignoreDsl && type.isDsl() }
-            ?.takeUnless { type.isAnnotatedWithAnyOf(ignoreAnnotated) }
+            ?.takeUnless { type.isAnnotatedWithAnyOf(ignoredAnnotations) }
             ?.let { type.returnTypeReference }
             ?.getAbbreviatedTypeOrType(bindingContext)
             ?.takeIf(KotlinType::isUnitNothingOrVoid)
@@ -93,7 +93,7 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         bindingContext.takeIf { it != BindingContext.EMPTY }
-            ?.takeUnless { function.isAnnotatedWithAnyOf(ignoreAnnotated) }
+            ?.takeUnless { function.isAnnotatedWithAnyOf(ignoredAnnotations) }
             ?.takeUnless { function.isMainFunction() }
             ?.get(BindingContext.FUNCTION, function)
             ?.returnType

--- a/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
+++ b/src/main/kotlin/pl/setblack/detekt/kurepotlin/rules/ReturnUnit.kt
@@ -30,8 +30,8 @@ import pl.setblack.detekt.kurepotlin.isMainFunction
  */
 class ReturnUnit(config: Config = Config.empty) : Rule(config) {
 
-    private val checkFunctionType: Boolean
-        get() = valueOrDefault("checkFunctionType", true)
+    private val ignoreFunctionType: Boolean
+        get() = valueOrDefault("ignoreFunctionType", false)
 
     private val ignoreAnnotated: List<String>
         get() = valueOrDefaultCommaSeparated("ignoreAnnotated", emptyList())
@@ -72,11 +72,11 @@ class ReturnUnit(config: Config = Config.empty) : Rule(config) {
 
     override fun visitFunctionType(type: KtFunctionType) {
         bindingContext.takeIf { it != BindingContext.EMPTY }
-            ?.takeIf { checkFunctionType }
+            ?.takeUnless { ignoreFunctionType }
             ?.takeUnless { ignoreDsl && type.isDsl() }
+            ?.takeUnless { type.isAnnotatedWithAnyOf(ignoreAnnotated) }
             ?.let { type.returnTypeReference }
             ?.getAbbreviatedTypeOrType(bindingContext)
-            ?.takeUnless { type.isAnnotatedWithAnyOf(ignoreAnnotated) }
             ?.takeIf(KotlinType::isUnitNothingOrVoid)
             ?.let {
                 val file = type.containingKtFile

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -78,6 +78,7 @@ class ReturnUnitSpec : Spek({
             val messages = subject.lintWithContext(env, impureUnitCode).map(Finding::message)
             assertThat(messages).containsExactly(
                 "Function impureUnitLambda in the file Test.kt returns nothing.",
+                "Function nonDslParameter in the file Test.kt returns nothing.",
                 "Function impureUnitExplicit in the file Test.kt returns nothing.",
                 "Function impureUnitImplicit in the file Test.kt returns nothing.",
                 "Function impureUnitExpression in the file Test.kt returns nothing.",

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -108,7 +108,7 @@ class ReturnUnitSpec : Spek({
     describe("a rule suppressed by ") {
 
         val subject by memoized {
-            ReturnUnit(TestConfig("ignoreAnnotated" to "IO"))
+            ReturnUnit(TestConfig("ignoredAnnotations" to "IO"))
         }
 
         it("find returns of Unit") {

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -78,7 +78,7 @@ class ReturnUnitSpec : Spek({
         }
     }
 
-    describe("a rule with dsl allowed") {
+    describe("a rule with dsl ignored") {
         val subject by memoized { ReturnUnit(TestConfig("ignoreDsl" to true)) }
 
         it("should find only non-dsl") {
@@ -105,7 +105,7 @@ class ReturnUnitSpec : Spek({
         }
     }
 
-    describe("a rule suppressed by ") {
+    describe("a rule suppressed by IO annotation") {
 
         val subject by memoized {
             ReturnUnit(TestConfig("ignoredAnnotations" to "IO"))

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -39,6 +39,8 @@ class ReturnUnitSpec : Spek({
                 "Function ImpureUnitFunctionType in the file Test.kt returns nothing.",
                 "Function impureUnitLambda in the file Test.kt returns nothing.",
                 "Function impureParameter in the file Test.kt returns nothing.",
+                "Function nonDslParameter in the file Test.kt returns nothing.",
+                "Function nonDslParameter in the file Test.kt returns nothing.",
                 "Function impureUnitExplicit in the file Test.kt returns nothing.",
                 "Function impureUnitImplicit in the file Test.kt returns nothing.",
                 "Function impureUnitExpression in the file Test.kt returns nothing.",
@@ -111,6 +113,10 @@ private const val impureUnitCode: String =
 
         fun impureParameterFunction(impureParameter: () -> Unit) = "impure"
 
+        fun dslParameterFunction(dslParameter: DslBuilder.() -> Unit = {}) = "impure"
+        
+        fun nonDslParameterFunction(nonDslParameter: DslBuilder.(String) -> Unit = {}) = "impure"
+
         fun impureUnitExplicit(): Unit { }
         
         fun impureUnitImplicit() { }
@@ -124,6 +130,8 @@ private const val impureUnitCode: String =
         fun main(args: Array<String>) {
             // pure
         }
+
+        class DslBuilder { }
     """
 
 private const val impureUnitSuppressedCode: String =

--- a/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
+++ b/src/test/kotlin/pl/setblack/detekt/kurepotlin/ReturnUnitSpec.kt
@@ -92,7 +92,7 @@ class ReturnUnitSpec : Spek({
 
     describe("a rule not checking function types") {
 
-        val subject by memoized { ReturnUnit(TestConfig("checkFunctionType" to false)) }
+        val subject by memoized { ReturnUnit(TestConfig("ignoreFunctionType" to true)) }
 
         it("find returns of Unit") {
             val messages = subject.lintWithContext(env, impureUnitCode).map(Finding::message)


### PR DESCRIPTION
* ignored previously unhandled `main` function variation
* added possibility to ignore DSL (detected when lambda or function type has a receiver and no parameter)
* added possibility to ignore functions/f.types/lambdas annotated with a configured annotation
* renamed `checkFunctionType` config to `ignoreFunctionType` for consistency
* updated README

This pull request doesn't change any default behaviour of `ReturnUnit` rule (apart from fix for `main` function).